### PR TITLE
Fix respond order in code

### DIFF
--- a/src/remind.coffee
+++ b/src/remind.coffee
@@ -78,14 +78,6 @@ module.exports = (robot) ->
         old = [user, message, executionDate]
         BrainReminders().splice BrainReminders().indexOf old, 1
 
-    robot.respond /remind( me)? (.+)/i, id: "remind.new", (res) ->
-        [status, reminder] = Reminder.addPending res.message.user, res.match[2]
-        if status isnt false
-            res.reply "When should I remind you?"
-        else
-            res.reply "You have a reminder pending creation. When should I remind you \"#{reminder[1]}\" ?"
-        res.finish()
-
     robot.respond /remind cancel/i, id: "remind.cancel", (res) ->
         if Reminder.cancelPending res.message.user
             res.reply "Your reminder operation has been cancelled."
@@ -114,6 +106,14 @@ module.exports = (robot) ->
             res.reply "#{cleared} of your reminder(s) have been cleared."
         else
             res.reply "You have no reminders."
+        res.finish()
+
+    robot.respond /remind( me)? (.+)/i, id: "remind.new", (res) ->
+        [status, reminder] = Reminder.addPending res.message.user, res.match[2]
+        if status isnt false
+            res.reply "When should I remind you?"
+        else
+            res.reply "You have a reminder pending creation. When should I remind you \"#{reminder[1]}\" ?"
         res.finish()
 
     robot.hear /(.+)/i, id: "remind.process", (res) ->


### PR DESCRIPTION
This prevents the first regex from catching the ones below it and
preventing them from triggering.
